### PR TITLE
Check if sox is installed (macOS)

### DIFF
--- a/R/mp32wav.R
+++ b/R/mp32wav.R
@@ -45,8 +45,18 @@ mp32wav <- function(samp.rate = NULL, parallel = 1, path = NULL,
   if (!requireNamespace("bioacoustics", quietly = TRUE) & !is.null(samp.rate))
     stop2("must install 'bioacoustics' to use mp32wav() for changing sampling rate")
   
-  
-  
+  # error message if sox is not installed / available on path (Darwin)
+  if (Sys.info()[1] == "Darwin") {
+                return <-
+                        system(paste("which sox", sep = " "),
+                               ignore.stderr = TRUE,
+                               intern = FALSE,
+                               ignore.stdout = TRUE)
+                
+                if (return == 1) {
+                        stop2("Sox is not installed or is not available in path")
+                }
+        }
   
   #### set arguments from options
   # get function arguments


### PR DESCRIPTION
- adds a check to `mp32wav.R` to see if sox is installed / available on the path environment variable 
- only runs this check if `Sys.info()[1] == "Darwin"`. I'm not sure how to do this check on windows/linux 
- https://github.com/maRce10/warbleR/issues/53#issuecomment-1302599663